### PR TITLE
Fixes for Android & iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Convert html strings to PDF documents using React Native
 
 ### Option 1: Automatic
 
-2. Run `react-native link`
+2. React Native >=0.60.0: nothing more to do
+
+2. React Native <0.60.0: Run `react-native link`
 
 ### Option 2: Manual
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,29 +12,30 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.5.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
 }
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
 
 apply plugin: 'com.android.library'
 
 android {
-     compileSdkVersion rootProject.ext.compileSdkVersion
-     compileOptions {
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
+    buildToolsVersion safeExtGet('buildToolsVersion', '28.0.3')
+    compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    compileSdkVersion 26
-  compileSdkVersion rootProject.ext.compileSdkVersion
-
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
         versionCode 1
         versionName "1.0"
         ndk {
@@ -49,6 +50,8 @@ repositories {
 
 
 dependencies {
-    implementation 'com.tom_roush:pdfbox-android:1.8.10.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
+    implementation 'com.tom_roush:pdfbox-android:1.8.10.1'
     implementation 'com.facebook.react:react-native:+'
 }

--- a/android/src/main/java/android/print/PdfConverter.java
+++ b/android/src/main/java/android/print/PdfConverter.java
@@ -96,7 +96,7 @@ public class PdfConverter implements Runnable {
         });
         WebSettings settings = mWebView.getSettings();
         settings.setDefaultTextEncodingName("utf-8");
-        mWebView.loadData(mHtmlString, "text/HTML; charset=utf-8", null);
+        mWebView.loadDataWithBaseURL(mBaseURL, mHtmlString, "text/HTML", "utf-8", null);
     }
 
     public PrintAttributes getPdfPrintAttrs() {

--- a/ios/RNHTMLtoPDF/RNHTMLtoPDF.m
+++ b/ios/RNHTMLtoPDF/RNHTMLtoPDF.m
@@ -216,7 +216,7 @@ RCT_EXPORT_METHOD(convert:(NSDictionary *)options
         _rejectBlock(RCTErrorUnspecified, nil, RCTErrorWithMessage(error.description));
     }
 }
-- (void)webViewDidFinishLoad:(UIWebView *)awebView
+- (void)webViewDidFinishLoad:(WKWebView *)awebView
 {
     
 }


### PR DESCRIPTION
Hi @patelgaurav4u,

as yours was the first HTML to PDF converter I could get to work successfully  (all others I tried having failed me)
in a corporate gig I'm currently working at as sole developer, I wanted to give back what I had to change in the
last few months using `patch-package` in the repo (outside repos aren't allowed, so I had to refer to that).

The changes are:
- [x] fixed loading of image assets in Android X - `loadDataWithBaseURL()` instead of `loadData()`
- [x] fixed integration into Android X projects by getting the SDK version from the main project and adapting libraries
- [x] fixed `webViewDidFinishLoad` still being used from `UIWebView`
- [x] adapted the installation instructions in `README.md` for RN >=0.60

Hope this PR makes it in and you might be able to publish a new version, as `patch-package` sometimes breaks our Bamboo builds ; ).

Best,

Tim.